### PR TITLE
PROD-504 - create service monitor for wattpro services

### DIFF
--- a/chart/templates/_servicemonitor.yaml
+++ b/chart/templates/_servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- define "prometheus.servicemonitor" }}
+{{- $ := index . 0 }}
+
+{{- with index . 1 }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Values.namespace | default "platformatic" }}
+  labels:
+    {{- include "application.labels" $ | nindent 4 }}
+    {{- include "application.selectorLabels" (merge (dict "name" .name) $) | nindent 4 }}
+
+spec:
+  selector:
+    matchLabels:
+      {{- include "application.selectorLabels" (merge (dict "name" .name) $) | nindent 6 }}
+  endpoints:
+    - port: "metrics"
+      honorLabels: false
+      interval: "15s"
+      relabelings:
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_pod_label_app_kubernetes_io_name
+          targetLabel: name
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+          targetLabel: instance
+{{- end }}
+{{- end }}

--- a/chart/templates/monitoring.yaml
+++ b/chart/templates/monitoring.yaml
@@ -1,31 +1,11 @@
+{{- if .Values.wattpro.monitor.enable }}
+---
+{{- include "prometheus.servicemonitor" (list $ .Values.wattpro.monitor) }}
+{{- end }}
+
 {{- range $service, $val := .Values.services }}
 ---
 {{- if .monitor.enabled -}}
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: {{ .name }}
-  namespace: {{ $.Values.namespace | default "platformatic" }}
-  labels:
-    {{- include "application.labels" $ | nindent 4 }}
-    {{- include "application.selectorLabels" (merge (dict "name" .name) $) | nindent 4 }}
-
-spec:
-  selector:
-    matchLabels:
-      {{- include "application.selectorLabels" (merge (dict "name" .name) $) | nindent 6 }}
-  endpoints:
-    - port: "metrics"
-      honorLabels: false
-      interval: "15s"
-      relabelings:
-        - action: replace
-          sourceLabels:
-            - __meta_kubernetes_pod_label_app_kubernetes_io_name
-          targetLabel: name
-        - action: replace
-          sourceLabels:
-            - __meta_kubernetes_pod_label_app_kubernetes_io_instance
-          targetLabel: instance
+{{- include "prometheus.servicemonitor" (list $ .) }}
 {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,6 +15,11 @@ imagePullSecret:
 ingress:
   enabled: false
 
+wattpro:
+  monitor:
+    enable: true
+    name: "wattpro"
+
 services:
   icc:
     name: icc


### PR DESCRIPTION
This is for development and to act as a demontration to customers, so it is intentionally simple.

The PR moves the `ServiceMonitor` to a template file. We then include it with different value context so that we can use the same resource for our applications as well as wattpro services