### PR TITLE
Apply role to assume for elasticache to icc pod

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: helm
 description: Platformatic microservices
 type: application
-version: 3.3.0
+version: 3.3.1
 appVersion: 1.0.0

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -4,10 +4,12 @@ kind: ServiceAccount
 metadata:
   name: {{ include "application.serviceAccountName" $ }}
   namespace: {{ .namespace | default "platformatic" }}
-  {{- with .annotations }}
+  {{- if eq .Values.cloud "aws"}}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- with .Values.services.icc.elasticacheRoleArn}}
+    eks.amazonaws.com/role-arn: {{ . }}
+    {{- end}}
+  {{- end}}
 
 {{- range $serviceAccount, $val := .Values.serviceAccounts }}
 ---


### PR DESCRIPTION
This allows for the AWS SDK to assume the role ARN. Documentation has been updated: https://www.notion.so/platformatic/Elasticache-for-ICC-23b4fa802f368091b753e3caafdbd084