### PR TITLE
add eBPF sandbox DaemonSet for per-node sandbox enforcement

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: helm
-version: 4.0.2-alpha7
+version: 4.0.3-alpha1
 kubeVersion: ">= 1.30.0-0"
 description: Platformatic microservices
 type: application

--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -1,0 +1,4 @@
+{{- if and .Values.services.ebpfSandbox .Values.services.ebpfSandbox.deploy }}
+---
+{{- include "daemonset.ebpf-sandbox" (list $ .Values.services.ebpfSandbox) }}
+{{- end }}

--- a/chart/templates/daemonset/_ebpf-sandbox.yaml
+++ b/chart/templates/daemonset/_ebpf-sandbox.yaml
@@ -101,6 +101,10 @@ spec:
           env:
             - name: NODE_ENV
               value: "production"
+            {{- if .disableEBPFPolicies }}
+            - name: PLT_SANDBOX_DISABLE_ENFORCEMENT
+              value: "true"
+            {{- end }}
             {{- with .env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/chart/templates/daemonset/_ebpf-sandbox.yaml
+++ b/chart/templates/daemonset/_ebpf-sandbox.yaml
@@ -1,0 +1,165 @@
+{{- define "daemonset.ebpf-sandbox" }}
+{{- $ := index . 0 }}
+
+{{- with index . 1 }}
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .name }}
+  namespace: {{ include "install.namespace" $ }}
+  labels:
+    {{- include "application.labels" $ | nindent 4 }}
+    {{- include "application.selectorLabels" (merge (dict "name" .name) $) | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "application.selectorLabels" (merge (dict "name" .name) $) | nindent 6 }}
+  template:
+
+    metadata:
+      {{- with .podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      labels:
+        {{- with .podLabels }}
+        {{- toYaml .| nindent 8 }}
+        {{- end }}
+        {{- include "application.selectorLabels" (merge (dict "name" .name) $) | nindent 8 }}
+
+    spec:
+      {{- with $.Values.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ $.Values.imagePullSecret.name | default "image-pull-secret" }}
+      {{- end }}
+
+      hostPID: true
+
+      volumes:
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: bpffs
+          hostPath:
+            path: /sys/fs/bpf
+            type: DirectoryOrCreate
+        - name: sandbox-sock
+          hostPath:
+            path: /var/run/platformatic-sandbox
+            type: DirectoryOrCreate
+        - name: debugfs
+          hostPath:
+            path: /sys/kernel/debug
+            type: Directory
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing
+            type: DirectoryOrCreate
+        {{- with .volumes }}
+        {{- range $volume, $value := . }}
+        - name: {{ .name }}
+          {{- if .hostPath }}
+          hostPath:
+            path: {{ .hostPath.path }}
+            type: {{ .hostPath.type | default "Directory" }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ .name }}-pvc
+          {{- end }}
+        {{- end }}
+        {{- end }}
+
+      serviceAccountName: {{ .name }}
+      {{- with .podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .name }}
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - BPF
+                - NET_ADMIN
+                - SYS_RESOURCE
+          image: "{{ .image.repository }}:{{ .image.tag | default "latest" }}"
+          imagePullPolicy: {{ .image.pullPolicy | default "IfNotPresent" }}
+
+          args:
+            - node
+            - {{ .entrypoint | default "src/index.ts" }}
+            - --socket={{ .socketPath }}
+            - --metrics-port={{ .metricsPort | default 8443 }}
+            - --bpf-dir={{ .bpfDir | default "/app/bpf" }}
+            - --cgroup-base={{ .cgroupBase | default "/sys/fs/cgroup/platformatic" }}
+
+          env:
+            - name: NODE_ENV
+              value: "production"
+            {{- with .env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+          volumeMounts:
+            - name: cgroup
+              mountPath: /sys/fs/cgroup
+            - name: bpffs
+              mountPath: /sys/fs/bpf
+            - name: sandbox-sock
+              mountPath: /var/run/platformatic-sandbox
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+            - name: tracefs
+              mountPath: /sys/kernel/tracing
+            {{- with .volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+          ports:
+            - name: metrics
+              protocol: TCP
+              containerPort: {{ .metricsPort }}
+
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: metrics
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+
+          resources:
+            {{- if .resources }}
+            {{- toYaml .resources | nindent 12 }}
+            {{- else }}
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            {{- end }}
+
+      {{- with .nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/chart/templates/monitoring.yaml
+++ b/chart/templates/monitoring.yaml
@@ -15,3 +15,9 @@
 {{- include "prometheus.servicemonitor" (list $ .Values.services.workflow) }}
 {{- end }}
 {{- end }}
+
+{{- if and $.Values.services.ebpfSandbox $.Values.services.ebpfSandbox.deploy $.Values.services.ebpfSandbox.monitor }}
+{{- if $.Values.services.ebpfSandbox.monitor.enable -}}
+{{- include "prometheus.servicemonitor" (list $ .Values.services.ebpfSandbox) }}
+{{- end }}
+{{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -28,3 +28,24 @@ spec:
     {{- include "application.selectorLabels" (merge (dict "name" .name) $) | nindent 4 }}
 {{- end }}
 {{- end }}
+
+{{- if and .Values.services.ebpfSandbox .Values.services.ebpfSandbox.deploy }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.services.ebpfSandbox.name }}-metrics
+  namespace: {{ include "install.namespace" $ }}
+  labels:
+    {{- include "application.labels" $ | nindent 4 }}
+    {{- include "application.selectorLabels" (merge (dict "name" .Values.services.ebpfSandbox.name) $) | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.services.ebpfSandbox.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "application.selectorLabels" (merge (dict "name" .Values.services.ebpfSandbox.name) $) | nindent 4 }}
+{{- end }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -41,6 +41,44 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 
+{{- if and .Values.services.ebpfSandbox .Values.services.ebpfSandbox.deploy }}
+{{- $ebpfName := "ebpf-sandbox" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $ebpfName }}
+  namespace: {{ include "install.namespace" $ }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $ebpfName }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $ebpfName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $ebpfName }}
+    namespace: {{ include "install.namespace" $ }}
+roleRef:
+  kind: ClusterRole
+  name: {{ $ebpfName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+
 {{- $accountName := "plt-pod-manager" }}
 ---
 apiVersion: v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -256,6 +256,10 @@ services:
     # Base cgroup path for Platformatic workloads
     cgroupBase: /sys/fs/cgroup/platformatic
 
+    # Disable eBPF policy enforcement (uses NoopEbpfManager)
+    # Set to true for environments without BPF LSM (e.g. macOS dev)
+    disableEBPFPolicies: false
+
     # Resource limits and requests
     #resources:
     #  limits:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -237,6 +237,10 @@ services:
       pullPolicy: IfNotPresent
       tag: "latest"
 
+    # Prometheus ServiceMonitor
+    monitor:
+      enable: true
+
     # Available levels: debug, info, warn, error
     log_level: info
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -223,6 +223,62 @@ services:
     # Nodes to join
     #affinity: {}
 
+  # eBPF Sandbox Server — per-node eBPF-based sandbox enforcement
+  ebpfSandbox:
+    # Used in URLs and referencing daemonsets, pods, and secrets
+    name: ebpf-sandbox
+
+    # Set to true to deploy the eBPF Sandbox Server
+    deploy: false
+
+    # We have a changelog available at:
+    image:
+      repository: platformatic/ebpf-sandbox-server
+      pullPolicy: IfNotPresent
+      tag: "latest"
+
+    # Available levels: debug, info, warn, error
+    log_level: info
+
+    # Unix socket path for sandbox communication
+    socketPath: /var/run/platformatic-sandbox/sandbox.sock
+
+    # Metrics endpoint port
+    metricsPort: 8443
+
+    # Directory containing compiled BPF programs
+    bpfDir: /app/bpf
+
+    # Base cgroup path for Platformatic workloads
+    cgroupBase: /sys/fs/cgroup/platformatic
+
+    # Resource limits and requests
+    #resources:
+    #  limits:
+    #    cpu: 500m
+    #    memory: 512Mi
+    #  requests:
+    #    cpu: 100m
+    #    memory: 128Mi
+
+    # Additional volumes
+    #volumes: []
+
+    # Additional volume mounts
+    #volumeMounts: []
+
+    # Additional pod annotations
+    #podAnnotations: {}
+
+    # Selector labels for the nodes to provision ebpf-sandbox to
+    #nodeSelector: {}
+
+    # Nodes to avoid
+    #tolerations: []
+
+    # Nodes to join
+    #affinity: {}
+
   # Workflow Service — durable workflow execution engine
   workflow:
     # Used in URLs and referencing deployments, pods, and secrets


### PR DESCRIPTION
## Summary

- Add `services.ebpfSandbox` to values.yaml (disabled by default, `deploy: false`)
- Add DaemonSet template with privileged security context, host mounts for cgroup/bpf/tracefs/socket
- Add `ebpf-sandbox` ServiceAccount with ClusterRole for node/pod read access
- Add `ebpf-sandbox-metrics` ClusterIP Service on port 8443

The DaemonSet runs one eBPF sandbox server pod per node, providing kernel-level process isolation via eBPF LSM hooks, cgroups v2, and Linux namespaces.

Host volumes mounted:
- `/sys/fs/cgroup` -- cgroup management
- `/sys/fs/bpf` -- BPF filesystem
- `/sys/kernel/debug` + `/sys/kernel/tracing` -- tracepoint access
- `/var/run/platformatic-sandbox` -- Unix socket shared with app pods