### PR TITLE
Support for ICC managed deployment

### DIFF
--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -130,6 +130,21 @@ rules:
       - services
     verbs:
       - delete
+  {{- if .Values.services.icc.features.skew_protection.manage_mode }}
+  # Skew protection manage mode (opt-in): ICC creates versioned Deployments and
+  # Services. Only granted when features.skew_protection.manage_mode is true;
+  # observe/advise modes never need it (advise applies via the external actor).
+  - apiGroups:
+      - ""
+      - apps
+    resources:
+      - deployments
+      - services
+    verbs:
+      - create
+      - update
+      - patch
+  {{- end }}
   # Gateway API - for skew protection (opt-in)
   - apiGroups:
       - gateway.networking.k8s.io

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -83,6 +83,7 @@ services:
         enable: false
       skew_protection:
         enable: false
+        manage_mode: false                   # Grant ICC create/update/patch on Deployments+Services (manage-mode deploys). Off = least privilege
         auto_cleanup: false                  # Delete expired Deployment and Service resources
         http_grace_period_ms: 1800000        # Min time to keep HTTP version draining (30 min)
         http_max_alive_ms: 86400000          # Hard deadline for HTTP versions (24h)


### PR DESCRIPTION
Opt-in RBAC so ICC can create workloads in skew-protection **manage** mode.

## Changes
- New value `services.icc.features.skew_protection.manage_mode` (default `false`).
- When `true`, the `plt-pod-manager` ClusterRole is granted `create/update/patch`  on `deployments`/`services`. Gated behind the value → **off by default = least privilege**; `observe`/`advise` never need it (advise applies via the external actor's own creds).
- Existing skew RBAC (httproutes CRUD, deployments/services `delete`) unchanged.

## Verification
`helm template`: rule **absent** by default, **present** with `manage_mode=true`;
