### PR TITLE
Grant machinist RBAC to create image pull secrets

### DIFF
--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -144,6 +144,17 @@ rules:
       - create
       - update
       - patch
+  # Image-pull secrets: the deploy API creates a dockerconfigjson Secret from the
+  # registry credentials in the request so a private image can be pulled. Applied
+  # via server-side apply, so only create + patch are needed -- never get (which
+  # would expose secret contents) or update/delete.
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - patch
   {{- end }}
   # Gateway API - for skew protection (opt-in)
   - apiGroups:

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -130,10 +130,11 @@ rules:
       - services
     verbs:
       - delete
-  {{- if .Values.services.icc.features.skew_protection.manage_mode }}
-  # Skew protection manage mode (opt-in): ICC creates versioned Deployments and
-  # Services. Only granted when features.skew_protection.manage_mode is true;
-  # observe/advise modes never need it (advise applies via the external actor).
+  {{- if .Values.services.icc.features.deployer.enable }}
+  # ICC deployer (opt-in): the deploy API creates the workload -- versioned
+  # Deployments and Services -- so the pod can boot and register. Independent of
+  # skew protection. Only granted when features.deployer.enable is true;
+  # observe-only installs (the customer's CI creates the workload) never need it.
   - apiGroups:
       - ""
       - apps

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -81,9 +81,10 @@ services:
         enable: false
       scaler_trends_learning:
         enable: false
+      deployer:
+        enable: false                        # ICC deployer creates workloads via the deploy API (Deployments/Services/pull Secrets). Off = observe-only, least privilege
       skew_protection:
         enable: false
-        manage_mode: false                   # Grant ICC create/update/patch on Deployments+Services (manage-mode deploys). Off = least privilege
         auto_cleanup: false                  # Delete expired Deployment and Service resources
         http_grace_period_ms: 1800000        # Min time to keep HTTP version draining (30 min)
         http_max_alive_ms: 86400000          # Hard deadline for HTTP versions (24h)


### PR DESCRIPTION
The deployer API in icc-3 creates a dockerconfigjson Secret from the registry credentials in a deploy request so a private image can be pulled, and machinist applies it to the target namespace. This grants the plt-pod-manager ServiceAccount the permission to do that.

Adds `secrets: [create, patch]` to the plt-pod-manager ClusterRole, next to the existing workload-create permissions (gated on `features.skew_protection.manage_mode`). Least privilege: the Secret is written with server-side apply, so only create and patch are needed -- never `get` (which would expose secret contents), nor update or delete.

Requires platformatic/machinist#74 and is required by platformatic/icc-3#909.
