### PR TITLE
Add skew protection routing mode to Helm chart

### DIFF
--- a/chart/templates/deployment/_icc.yaml
+++ b/chart/templates/deployment/_icc.yaml
@@ -139,6 +139,10 @@ spec:
             - name: PLT_SKEW_COOKIE_MAX_AGE
               value: "{{ . }}"
             {{- end }}
+            {{- with dig "features" "skew_protection" "routing_mode" nil . }}
+            - name: PLT_SKEW_ROUTING_MODE
+              value: "{{ . }}"
+            {{- end }}
             - name: DEV_K8S
               value: '{{ dig "features" "dev_mode" "enable" false . | toString }}'
 

--- a/chart/templates/deployment/_icc.yaml
+++ b/chart/templates/deployment/_icc.yaml
@@ -139,8 +139,8 @@ spec:
             - name: PLT_SKEW_COOKIE_MAX_AGE
               value: "{{ . }}"
             {{- end }}
-            {{- with dig "features" "skew_protection" "routing_mode" nil . }}
-            - name: PLT_SKEW_ROUTING_MODE
+            {{- with dig "features" "skew_protection" "default_routing_mode" nil . }}
+            - name: PLT_SKEW_DEFAULT_ROUTING_MODE
               value: "{{ . }}"
             {{- end }}
             - name: DEV_K8S

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -95,8 +95,10 @@ services:
         cookie_max_age: 43200                # Max age for session cookie in seconds (12h)
         # How clients carry their version: `query` (the default -- a ?dpl baked
         # into the built assets) or `cookie` (the gateway sets __plt_dpl).
-        # Cluster-wide, because whether builds bake the id is a property of your
-        # build pipeline, not of an individual app.
+        # This is the cluster default; an application can override it in ICC.
+        # It exists because both reasons for needing `cookie` -- a gateway that
+        # cannot match query params, or a build pipeline that cannot stamp the
+        # id -- are usually properties of the cluster rather than of one app.
         #
         # The two are strictly exclusive and there is NO fallback between them.
         # In query mode a version whose image was not built with its own id as

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -93,18 +93,23 @@ services:
         check_interval_ms: 60000             # How often to check draining versions (1 min)
         traffic_window_ms: 1800000           # Time window for traffic activity tracking (30 min)
         cookie_max_age: 43200                # Max age for session cookie in seconds (12h)
-        # How clients carry their version: `cookie` (the gateway sets __plt_dpl)
-        # or `query` (a ?dpl baked into the built assets). Cluster-wide, because
-        # whether builds bake it is a property of your build pipeline. A version
-        # not built with its own id keeps the cookie automatically, so switching
-        # cannot silently unprotect anything.
+        # How clients carry their version: `query` (the default -- a ?dpl baked
+        # into the built assets) or `cookie` (the gateway sets __plt_dpl).
+        # Cluster-wide, because whether builds bake the id is a property of your
+        # build pipeline, not of an individual app.
         #
-        # `query` requires a gateway controller that implements queryParams
+        # The two are strictly exclusive and there is NO fallback between them.
+        # In query mode a version whose image was not built with its own id as
+        # PLT_DEPLOYMENT_ID gets no pinning rule at all -- it is unprotected, not
+        # silently downgraded to a cookie. Set `cookie` if your builds do not
+        # pass PLT_DEPLOYMENT_ID yet.
+        #
+        # `query` also requires a gateway controller that implements queryParams
         # matching. That is Extended support in the Gateway API, not Core, so a
         # fully conformant controller may lack it -- check that yours reports the
         # HTTPRouteQueryParamMatching conformance feature. Verified on Envoy
         # Gateway v1.4.2. Cookie mode has no such prerequisite.
-        routing_mode: cookie
+        routing_mode: query
 
     # Available levels: debug, info, warn, error
     log_level: warn

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -109,7 +109,7 @@ services:
         # fully conformant controller may lack it -- check that yours reports the
         # HTTPRouteQueryParamMatching conformance feature. Verified on Envoy
         # Gateway v1.4.2. Cookie mode has no such prerequisite.
-        routing_mode: query
+        default_routing_mode: query
 
     # Available levels: debug, info, warn, error
     log_level: warn

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -93,6 +93,18 @@ services:
         check_interval_ms: 60000             # How often to check draining versions (1 min)
         traffic_window_ms: 1800000           # Time window for traffic activity tracking (30 min)
         cookie_max_age: 43200                # Max age for session cookie in seconds (12h)
+        # How clients carry their version: `cookie` (the gateway sets __plt_dpl)
+        # or `query` (a ?dpl baked into the built assets). Cluster-wide, because
+        # whether builds bake it is a property of your build pipeline. A version
+        # not built with its own id keeps the cookie automatically, so switching
+        # cannot silently unprotect anything.
+        #
+        # `query` requires a gateway controller that implements queryParams
+        # matching. That is Extended support in the Gateway API, not Core, so a
+        # fully conformant controller may lack it -- check that yours reports the
+        # HTTPRouteQueryParamMatching conformance feature. Verified on Envoy
+        # Gateway v1.4.2. Cookie mode has no such prerequisite.
+        routing_mode: cookie
 
     # Available levels: debug, info, warn, error
     log_level: warn


### PR DESCRIPTION
Exposes `PLT_SKEW_DEFAULT_ROUTING_MODE` so a cluster can choose how clients carry their version for skew protection: `cookie` (the gateway sets `__plt_dpl` and matches it back) or `query` (a `?dpl=<version>` baked into the built assets, which the gateway matches).

The chart ships `default_routing_mode: query`, matching the ICC default. That is a behaviour change for an existing install on upgrade, and it is deliberate: query is the only mechanism both Kubernetes and ECS can implement, so it is the one worth defaulting to. Set `cookie` if your builds do not pass `PLT_DEPLOYMENT_ID` yet, since in query mode a version built without its own id gets no pinning rule at all rather than silently falling back to a cookie.

The name says `default` because it is the cluster default rather than the last word: ICC lets an individual application override it (platformatic/icc-3#975), so a fleet can convert its build pipelines one application at a time instead of flipping everything at once.

Both modes need a Gateway API feature beyond Core, and the guarantees are not equal. Query pinning needs `queryParams` matching, which is Extended and reported by the conformance suite as `HTTPRouteQueryParamMatching`. Cookie pinning needs `ResponseHeaderModifier` to set the cookie, also Extended, plus a `RegularExpression` header match to read it back, which the Gateway API classifies as Implementation Specific: no conformance feature name, no portability guarantee, no defined regex dialect. Both were verified on Envoy Gateway v1.4.2.

Worth knowing before choosing: the v1.3.0 conformance reports show GKE Gateway does not implement query-parameter matching, and the AWS Load Balancer Controller implements neither feature, so skew protection cannot work through that controller at all. Those are the clusters that need this value set, and they are the ones where the operator did not choose the controller.

The template plumbing follows the existing `dig` pattern used by the other `skew_protection` keys, so removing `default_routing_mode` from values omits the variable entirely and ICC applies its own default.

Verified by rendering the chart: the shipped values produce `PLT_SKEW_DEFAULT_ROUTING_MODE: "query"`, an explicit `services.icc.features.skew_protection.default_routing_mode: cookie` produces `"cookie"`, and setting the key to null omits the variable.

Requires platformatic/icc-3#975, which implements the routing mode this configures.
