### PR TITLE
fix: give workflow the same probe grace as icc

### DIFF
--- a/chart/templates/deployment/_workflow.yaml
+++ b/chart/templates/deployment/_workflow.yaml
@@ -108,8 +108,9 @@ spec:
             httpGet:
               path: /status
               port: http
-            failureThreshold: 3
-            initialDelaySeconds: 5
+            # Matches the icc probe timings.
+            failureThreshold: 5
+            initialDelaySeconds: 40
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -117,8 +118,8 @@ spec:
             httpGet:
               path: /status
               port: http
-            failureThreshold: 3
-            initialDelaySeconds: 5
+            failureThreshold: 5
+            initialDelaySeconds: 40
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1


### PR DESCRIPTION
In hotReload/dev mode the workflow container runs `pnpm install` from the mounted repo before it binds `:3042`, which takes well over the previous liveness grace of ~35s (`initialDelaySeconds: 5` + 3 × `periodSeconds: 10`). The kubelet SIGKILLed the pod mid-install (exit 137) and it fell into CrashLoopBackOff. icc runs the same hot-reload startup but has a ~90s grace and never trips.

This aligns the workflow liveness and readiness probes with icc (`initialDelaySeconds: 40`, `failureThreshold: 5`), giving the container enough time to finish installing and start serving `/status` before the probes begin failing.
